### PR TITLE
error handling & stdout

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,15 @@ function installify(filename) {
   }
 
   function resolver() {
-    var deps = detective(buffer).filter(function(pkg) {
+    var requires
+    try {
+      requires = detective(buffer)
+    } catch (e) {
+      stream.emit('error', e)
+      return
+    }
+
+    var deps = requires.filter(function(pkg) {
       return pkg[0] !== '.' && pkg[0] !== '/'
     })
 
@@ -57,7 +65,7 @@ function installify(filename) {
       , env: process.env
     })
 
-    proc.stderr.on('data', function(data) {
+    proc.stdout.on('data', function(data) {
       deptext += data
     })
 


### PR DESCRIPTION
with npm (npm@2.8.2) it seems to write to stdout, not stderr

also added try/catch to stop parse errors from breaking builds (i.e. budo) 
still seems to catch npm install errors correctly, but could add further diagnostics with `proc.stderr.pipe(process.stderr`