### PR TITLE
do not look for require statements in JSON files

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ module.exports = installify
 function truthy(a) { return a }
 
 function installify(filename, opt) {
+  if (/\.json$/i.test(filename)) return through()
   opt = opt||{}
   var stream = through(write, resolver)
   var buffer = ''


### PR DESCRIPTION
Right now it might break if a JSON has the word `require` in it.