### PR TITLE
Add yarn add support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # installify #
 
+
 A [browserify](http://browserify.org/) transform for the lazy JavaScripter: installify automatically installs missing dependencies when bundling for quick
 and dirty prototyping.
 
@@ -30,8 +31,26 @@ beefy index.js -- -t installify
 ## Options ##
 
 ```
-  --save, -S       save installs as a dependency
-  --save-dev, -D   save installs as a devDependency
+  --save-dev, -D       This will install a <package> in your devDependencies.
+  --save-exact, -E     This installs the package as an exact version.
+  --save-optional, -O  This will install a <package> in your optionalDependencies.
+  --save, -S           save installs as a dependency
+  --save-dev, -D       save installs as a devDependency
+  --yarn               use yarn instead of npm
+```
+
+Please note when using yarn the `package.json` will always be updated.
+
+## yarn add options ##
+
+All [yarn add](https://yarnpkg.com/en/docs/cli/add) options are supported:
+
+```
+  --save-dev, -D       This will install a <package> in your devDependencies.
+  --save-exact, -E     This installs the package as an exact version.
+  --save-optional, -O  This will install a <package> in your optionalDependencies.
+  --peer               This will install a <package> in your peerDependencies.
+  --tilde              This installs the most recent release of the package that has the same minor version.
 ```
 
 You can use the subarg syntax for CLI options, like this:

--- a/index.js
+++ b/index.js
@@ -16,11 +16,20 @@ function installify(filename, opt) {
   var buffer = ''
 
   var userArgs = []
-  if (opt.save || opt.S)
-    userArgs = ['--save']
-  else if (opt.saveDev || opt.D)
-    userArgs = ['--save-dev']
-  var installArgs = ['install'].concat(userArgs)
+  if (opt.yarn) {
+    if (opt.saveDev || opt.D) userArgs.push('--dev')
+    if (opt.saveOptional || opt.O) userArgs.push('--optional')
+    if (opt.saveExact || opt.E) userArgs.push('--exact')
+    if (opt.peer) userArgs.push('--peer')
+    if (opt.tilde) userArgs.push('--tilde')
+  } else {
+    if (opt.saveDev || opt.D) userArgs.push('--save-dev')
+    if (opt.saveOptional || opt.O) userArgs.push('--save-optional')
+    if (opt.saveExact || opt.E) userArgs.push('--save-exact')
+    if (opt.save || opt.S) userArgs.push('--save')
+    if (opt.saveDev || opt.D) userArgs.push('--save-dev')
+  }
+  var installArgs = [(opt.yarn ? 'add' : 'install')].concat(userArgs)
 
   function write(data) {
     buffer += data
@@ -60,9 +69,10 @@ function installify(filename, opt) {
   function install(dir, deps) {
     var deptext = ''
     var args = installArgs.concat(deps)
+    var client = opt.yarn ? 'yarn' : 'npm'
     var cmd = process.platform === 'win32'
-        ? 'npm.cmd'
-        : 'npm'
+        ? (client + '.cmd')
+        : client
 
     if (!deps.length) {
       stream.queue(buffer)


### PR DESCRIPTION
Please add `yarn` support.

The default is still `npm` but now `installify` could be used with `yarn` as follows :-

```
browserify ./test.js -t [ installify --yarn ]
```

or

```
browserify ./test.js -t [ installify --yarn --exact ]
```
